### PR TITLE
Improve embeddability

### DIFF
--- a/totalimpactwebapp/static/embed.css
+++ b/totalimpactwebapp/static/embed.css
@@ -1,24 +1,22 @@
-
-body {
+#ti-data {
     font-family: "Helvetica", sans-serif;
     margin: 0;
     height: 100%;
     padding-bottom: 0;
 }
 
-a {
+#ti-data a {
     color: #FF4E00;
     cursor: pointer;
     text-decoration: none
 }
 
-p, ul {
+#ti-data p, #ti-data ul {
     line-height: 1.4;
     font-size: 18px;
 }
 
-
-div#metrics {
+#ti-data div#metrics {
     min-height: 500px;
     margin-top:7px;
     padding-top:15px;
@@ -26,44 +24,46 @@ div#metrics {
     float: left;
     width: 100%;
 }
-div#metrics div.wrapper {
+
+#ti-data div#metrics div.wrapper {
 }
 
-ul.metrics li {
+#ti-data ul.metrics li {
     list-style-type:none;
 }
 
-ul.metrics {
+#ti-data ul.metrics {
     margin-left: 365px;
 }
-ul.metrics li, ul.metrics span.missing {
+
+#ti-data ul.metrics li, #ti-data ul.metrics span.missing {
     float: left;
     height: 6em;
     margin-right: 12px;
 }
 
-ul.metrics a {
+#ti-data ul.metrics a {
     text-align:center;
 }
 
-ul.metrics a:hover {
+#ti-data ul.metrics a:hover {
     text-decoration: none;
 }
 
-ul.metrics li:hover span.metric-name {
+#ti-data ul.metrics li:hover span.metric-name {
     color:#FF4E00;
 }
 
-ul.metrics span.last-update {
+#ti-data ul.metrics span.last-update {
     display:none; /* figure out how to display this later */
 }
 
-ul.metrics a:hover span.metric-value {
+#ti-data ul.metrics a:hover span.metric-value {
     background: #FF4E00;
     color:#fff;
 }
 
-ul.metrics span.metric-value {
+#ti-data ul.metrics span.metric-value {
     font-weight: bold;
     list-style-type:none;
     padding:0 5px;
@@ -74,7 +74,7 @@ ul.metrics span.metric-value {
     display:block;
 }
 
-.metric-name {
+#ti-data .metric-name {
     -moz-transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
     -ms-filter: 'progid:DXImageTransform.Microsoft.BasicImage(rotation=3)';
@@ -84,28 +84,29 @@ ul.metrics span.metric-value {
     width: 30px;
     margin: 7px auto 0;
 }
-span.meta-doi {
+
+#ti-data span.meta-doi {
     display: none;
 }
 
-span.metric-name-img {
+#ti-data span.metric-name-img {
     margin: 4px 3px;
 }
 
-span.metric-name-img img {
+#ti-data span.metric-name-img img {
     margin: 0 auto;
     display:block;
 }
 
-.metric-img-name {
+#ti-data .metric-img-name {
     display:block;
 }
 
-ul#items {
+#ti-data ul#items {
 
 }
 
-li.item {
+#ti-data li.item {
     border: 0 solid #CCCCCC;
     clear: left;
     list-style-type: none;
@@ -114,20 +115,19 @@ li.item {
     min-height: 4em;
 }
 
-li.item h4 {
+#ti-data li.item h4 {
     font-weight: normal;
     margin:0;
     color: #AAA;
     font-size : 12px;
 }
 
-li.item span.repo, li.item span.genre {
+#ti-data li.item span.repo, #ti-data li.item span.genre {
     color: #aaa;
     font-size:12px;
     margin-left: 5px;
 }
-li.item span.genre {
+
+#ti-data li.item span.genre {
     margin-left:0;
 }
-
-

--- a/totalimpactwebapp/static/embed.css
+++ b/totalimpactwebapp/static/embed.css
@@ -33,7 +33,6 @@
 }
 
 #ti-data ul.metrics {
-    margin-left: 365px;
 }
 
 #ti-data ul.metrics li, #ti-data ul.metrics span.missing {


### PR DESCRIPTION
Some changes which made the embed code fit more neatly into a DSpace 1.8 Mirage-themed item detail page.  CSS rules were not specific enough to TI and would affect other parts of the page.  I removed a big indent of the results list that didn't seem to be needed and was causing layout problems.
